### PR TITLE
Only sets `global.process` when running Bare

### DIFF
--- a/global.js
+++ b/global.js
@@ -1,1 +1,1 @@
-global.process = require('.')
+if (global.Bare) global.process = require('.')


### PR DESCRIPTION
Safely `require('bare-process/global')` execution between runtimes, not demanding much changes on stable codebases, and yet, spreading bare compatibility. 